### PR TITLE
clear selection after jumping

### DIFF
--- a/bounce.lua
+++ b/bounce.lua
@@ -13,7 +13,7 @@ end
 
 -- bounce cursor between start of line and first non-whitespace character
 -- slightly different than how micro's default home works, this is first non-whitespace
--- character, then start of line. micro works backwards, start of line, then 
+-- character, then start of line. micro works backwards, start of line, then
 -- the first non-whitespace character
 function smartHome(bp)
 	local c = bp.Buf:GetActiveCursor()
@@ -41,7 +41,7 @@ function bounce(bp)
 	end
 end
 
--- keepLoc / gotoStoredLoc - easier than memorizing line numbers 
+-- keepLoc / gotoStoredLoc - easier than memorizing line numbers
 local storedLoc = {}
 function keepLoc(bp)
 	storedLoc[bp.Buf.AbsPath] = -bp.Cursor.Loc
@@ -51,6 +51,7 @@ function gotoStoredLoc(bp)
 	local name = bp.Buf.AbsPath
 	if storedLoc[name] ~= nil then
 		bp.Cursor:GotoLoc(storedLoc[name])
+		bp.Cursor:ResetSelection()
 		bp:Relocate()
 	end
 end


### PR DESCRIPTION
in https://github.com/zyedidia/micro/issues/1563#issuecomment-746710748 you suggested to bind `CtrlF` to `"lua:bounce.keepLoc,Find"`.
I like that suggestion a lot, but I see an issue with it: when you search for something, micro selects that text - and because it is still selected, you cannot continue typing after jumping back to your stored location.